### PR TITLE
Do not require ohai_time attribute to be available on discovered nodes

### DIFF
--- a/libraries/search.rb
+++ b/libraries/search.rb
@@ -50,13 +50,21 @@ module Discovery
       Chef::Search::Query.new.search(:node, string) { |o| results << o }
 
       ohai_times = results.map do |node|
-        [ node.name, node.ohai_time ]
+        [ node.name, node.has_key?(:ohai_time) ? node.ohai_time : nil ]
       end
 
       Chef::Log.debug "discovery: found nodes with recent check in: #{ohai_times.inspect}"
 
       results.sort do |node_a, node_b|
-        node_a.ohai_time <=> node_b.ohai_time
+        if(node_a.has_key?(:ohai_time) && node_b.has_key?(:ohai_time))
+          node_a.ohai_time <=> node_b.ohai_time
+        elsif(node_a.has_key?(:ohai_time) && !node_b.has_key?(:ohai_time))
+          -1
+        elsif(!node_a.has_key?(:ohai_time) && node_b.has_key?(:ohai_time))
+          1
+        else
+          0
+        end
       end
     end
   end


### PR DESCRIPTION
Allows processing nodes that do not have an ohai time stored. This can happen when nodes have been created but have not yet converged. The sorting used will push nodes without ohai times to the end of the array.
