### PR TITLE
Use only ruby 1.8 compatible syntax in cookbook

### DIFF
--- a/libraries/recipe.rb
+++ b/libraries/recipe.rb
@@ -2,7 +2,9 @@ module Discovery
   module Recipe
 
     %w{search all}.each do |dsl_method|
-      define_method("discovery_#{dsl_method}") do |role='', args={}|
+      define_method("discovery_#{dsl_method}") do |*meth_args|
+        role = meth_args[0] || ''
+        args = meth_args[1] || {}
         Discovery.send(dsl_method, role, {:node => node}.merge(args))
       end
     end

--- a/libraries/search.rb
+++ b/libraries/search.rb
@@ -72,7 +72,8 @@ module Discovery
   class ResultProcessor
     attr_accessor :results, :options, :role
 
-    def initialize(results = [], options = {}, role)
+    def initialize(results = [], options = {}, role = nil)
+      raise ArgumentError, 'Missing role value' if role.nil?
       @results = results
       @options = options
       @role = role


### PR DESCRIPTION
Replace 1.9 method signatures with quite similar functionality
fixes #12
