### PR TITLE
Add name attribute to metadata

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -1,3 +1,4 @@
+name             "discovery"
 maintainer       "Heavy Water Operations, LLC"
 maintainer_email "support@hw-ops.com"
 license          "Apache 2.0"


### PR DESCRIPTION
Adding name attribute to metadata.rb. I'm using Berkshelf and uploading requires the name attribute to exist.
